### PR TITLE
Make runtimeclasspath an internal input for InspectClasspath

### DIFF
--- a/minimal-plugin/src/main/java/io/micronaut/gradle/ApplicationClasspathInspector.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/ApplicationClasspathInspector.java
@@ -19,8 +19,9 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.tasks.CacheableTask;
-import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
@@ -31,6 +32,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @CacheableTask
 public abstract class ApplicationClasspathInspector extends DefaultTask {
@@ -38,9 +40,13 @@ public abstract class ApplicationClasspathInspector extends DefaultTask {
     @PathSensitive(PathSensitivity.RELATIVE)
     public abstract ConfigurableFileCollection getResources();
 
-    @InputFiles
-    @Classpath
+    @Internal
     public abstract ConfigurableFileCollection getRuntimeClasspath();
+
+    @Input
+    public Set<String> getResolvedClasspathNames() {
+        return getRuntimeClasspath().getFiles().stream().map(File::getName).collect(Collectors.toSet());
+    }
 
     @OutputFile
     public abstract RegularFileProperty getReportFile();
@@ -51,8 +57,7 @@ public abstract class ApplicationClasspathInspector extends DefaultTask {
             Set<File> resources = getResources().getFiles();
             if (resources.stream().anyMatch(ApplicationClasspathInspector::isYamlConfigurationFile)) {
                 writer.println("YAML configuration file detected");
-                Set<File> runtimeClasspath = getRuntimeClasspath().getFiles();
-                if (runtimeClasspath.stream().noneMatch(f -> f.getName().startsWith("snakeyaml"))) {
+                if (getResolvedClasspathNames().stream().noneMatch(n -> n.startsWith("snakeyaml"))) {
                     writer.println("Didn't find snakeyaml on classpath. Failing");
                     throw new RuntimeException("YAML configuration file detected but snakeyaml is not on classpath. Make sure to add a runtimeOnly dependency on snakeyaml, e.g 'runtimeOnly(\"org.yaml:snakeyaml\")'");
                 }

--- a/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
+++ b/minimal-plugin/src/main/java/io/micronaut/gradle/MicronautComponentPlugin.java
@@ -297,7 +297,6 @@ public class MicronautComponentPlugin implements Plugin<Project> {
 
     private static TaskProvider<ApplicationClasspathInspector> registerInspectRuntimeClasspath(Project project, TaskContainer tasks) {
         return tasks.register(INSPECT_RUNTIME_CLASSPATH_TASK_NAME, ApplicationClasspathInspector.class, task -> {
-            var javaPluginExtension = PluginsHelper.javaPluginExtensionOf(project);
             task.setGroup(BasePlugin.BUILD_GROUP);
             task.setDescription("Performs sanity checks of the runtime classpath to warn about misconfigured builds");
             task.getRuntimeClasspath().from(project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));


### PR DESCRIPTION
Make runtimeclasspath an internal input, from which the resolvedClasspathNames are calculated and retreived as inputs.